### PR TITLE
removed name of editor after calling @component in editor.css

### DIFF
--- a/src/editor.css
+++ b/src/editor.css
@@ -8,7 +8,7 @@ body {
   font-size: 14px;
 }
 
-@component editor;
+@component;
 
 .wrap {
   display: flex;


### PR DESCRIPTION
In editor.css, the name of the "editor" need not be defined after @component, so I removed it.