### PR TITLE
Move/simplify templates stuff

### DIFF
--- a/src/editor.css
+++ b/src/editor.css
@@ -196,40 +196,13 @@
   margin: 10px 0;
 }
 
-.template {
-  flex: 1;
-  opacity: 0.9;
-  z-index: 0;
-  transition: opacity 0.2s ease, transform 0.2s ease;
-  cursor: pointer;
-}
-
-.templates-panel {
-  padding: 20px;
-  background: var(--content-bg);
-}
-
-.template:hover {
-  transform:scale(1.05);
-  opacity: 1;
-  z-index: 1;
-  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.4);
-}
-
 .delete-file-button {
   z-index:2;
   position: absolute;
   cursor: pointer;
 }
 
-.template video,
-.template img {
-  width: 100%;
-  display: block;
-  z-index: 10;
-}
-
-.content-toolbar .choose-templates {
+.content-toolbar .templates-button {
   margin-left: auto;
 }
 

--- a/src/editor.js
+++ b/src/editor.js
@@ -108,15 +108,15 @@ const renderEditor = ({
   codeMirrorElement,
   content = '',
   files = [],
-  isFullPreview = false,
   isFilesDragHintDisplayed = false,
   isFilesPanelDisplayed = false,
+  isFullPreview = false,
   isTemplatePanelDisplayed = false,
   previewElement,
   storyDocTemplate = '',
-  viewportId = viewportIdDefault,
   templates,
   templatesJson,
+  viewportId = viewportIdDefault,
 }) => html`
   <div id=${id} class=${n('wrap')}>
     ${FilesPanel({

--- a/src/editor.js
+++ b/src/editor.js
@@ -25,7 +25,6 @@ import {
   TemplatesJsonScriptOptional,
   TemplatesPanel,
 } from './template-loader';
-import {classMap} from 'lit-html/directives/class-map';
 import {CTA_TYPES} from './cta-types';
 import {Deferred} from '../vendor/ampproject/amphtml/src/utils/promise';
 import {getNamespace} from '../lib/namespace';

--- a/src/editor.js
+++ b/src/editor.js
@@ -90,10 +90,10 @@ const staticServerData = async () => ({
  *    (The SSR'd element is taken on runtime to manipulate independently, we
  *    bookkeep it so that it won't be overriden by the client-side rerender.)
  * @param {string=} data.storyDocTemplate
- * @param {Object<string, {previewExt: string, files: Array}>} templates
+ * @param {Object<string, {previewExt: string, files: Array}>} data.templates
  *    Templates definition.
  *    Displayed inside the `TemplatePanel`.
- * @param {string} templatesJson
+ * @param {string} data.templatesJson
  *    A definition of the above serialized as JSON.
  *    Used for inserting template definition by SSR. On the client, parsed
  *    value is passed as `templates`.

--- a/src/template-loader.css
+++ b/src/template-loader.css
@@ -1,0 +1,28 @@
+@component;
+
+.template {
+  flex: 1;
+  opacity: 0.9;
+  z-index: 0;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  cursor: pointer;
+}
+
+.panel {
+  padding: 20px;
+  background: var(--content-bg);
+}
+
+.template:hover {
+  transform: scale(1.05);
+  opacity: 1;
+  z-index: 1;
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.4);
+}
+
+.template video,
+.template img {
+  width: 100%;
+  display: block;
+  z-index: 10;
+}

--- a/src/template-loader.js
+++ b/src/template-loader.js
@@ -35,8 +35,13 @@ export const fetchTemplateContentFactory = win =>
     (await successfulFetch(win, templateFileUrl(name, 'index.html'))).text()
   );
 
-// Panel does not render when it is not displayed to allow for video
-// autoplay without bad performance (see hooseTemplatesButton)
+/**
+ * Does not render when not displayed for video autoplay.
+ * (See `TemplateSelector`)
+ * @param {boolean} isDisplayed
+ * @param {Object<string, {previewExt: string, files: Array}>} templates
+ * @return {lit-html/TemplateResult}
+ */
 export const TemplatesPanel = ({isDisplayed, templates}) =>
   isDisplayed
     ? html`

--- a/src/template-loader.js
+++ b/src/template-loader.js
@@ -89,8 +89,6 @@ export const TemplatesJsonScriptOptional = json =>
         </script>
       `;
 
-const dispatchToggleTemplates = redispatchAs(g('toggle-templates'));
-
 export const parseTemplatesJsonScript = parent =>
   JSON.parse(
     assert(parent.querySelector(s('script.templates'))).textContent.replace(
@@ -98,6 +96,8 @@ export const parseTemplatesJsonScript = parent =>
       '"'
     )
   );
+
+const dispatchToggleTemplates = redispatchAs(g('toggle-templates'));
 
 export const ChooseTemplatesButton = (setClassMap = {}) => html`
   <div

--- a/src/template-loader.js
+++ b/src/template-loader.js
@@ -31,6 +31,9 @@ const {g, n, s} = getNamespace('template-loader');
 export const templateFileUrl = (templateName, filename) =>
   `/static/templates/${templateName}/${filename}`;
 
+const templatePreviewFileUrl = (name, ext) =>
+  templateFileUrl(name, `_preview.${ext}`);
+
 export const fetchTemplateContentFactory = win =>
   memoize(async name =>
     (await successfulFetch(win, templateFileUrl(name, 'index.html'))).text()
@@ -74,17 +77,19 @@ const TemplateSelector = ({name, previewExt}) => html`
   </div>
 `;
 
-function TemplatePreview(name, ext) {
-  const url = templateFileUrl(name, `_preview.${ext}`);
-  if (ext == 'mp4' || ext == 'webm') {
-    return html`
-      <video autoplay loop muted src=${url}></video>
-    `;
-  }
-  return html`
-    <img src=${url} />
-  `;
-}
+const TemplatePreview = (name, ext) =>
+  ext == 'mp4' || ext == 'webm'
+    ? html`
+        <video
+          autoplay
+          loop
+          muted
+          src=${templatePreviewFileUrl(name, ext)}
+        ></video>
+      `
+    : html`
+        <img src=${templatePreviewFileUrl(name, ext)} />
+      `;
 
 export const TemplatesJsonScriptOptional = json =>
   !json

--- a/src/template-loader.js
+++ b/src/template-loader.js
@@ -21,6 +21,7 @@ import {identity} from './utils/function';
 import {redispatchAs} from './utils/events';
 import {repeat} from 'lit-html/directives/repeat';
 import {successfulFetch} from './utils/xhr';
+import {unsafeHTML} from 'lit-html/directives/unsafe-html';
 import memoize from 'lodash.memoize';
 
 import {getNamespace} from '../lib/namespace';
@@ -90,17 +91,12 @@ export const TemplatesJsonScriptOptional = json =>
     ? ''
     : html`
         <script type="application/json" class=${n('templates')}>
-          ${json}
+          ${unsafeHTML(json)}
         </script>
       `;
 
 export const parseTemplatesJsonScript = parent =>
-  JSON.parse(
-    assert(parent.querySelector(s('script.templates'))).textContent.replace(
-      /(&quot\;)/g,
-      '"'
-    )
-  );
+  JSON.parse(assert(parent.querySelector(s('script.templates'))).textContent);
 
 const dispatchToggleTemplates = redispatchAs(g('toggle-templates'));
 


### PR DESCRIPTION
- Move `templates` templates to `template-loader.js` with their own namespac
- Simplifies `TemplateLoader` into `fetchTemplateContentFactory` with [`_.memoize`](https://lodash.com/docs/4.17.11#memoize).
