### PR TITLE
Partially fix Safari support

### DIFF
--- a/src/amp-story-ad-preview.js
+++ b/src/amp-story-ad-preview.js
@@ -36,7 +36,6 @@ const defaultIframeSandbox = [
   'allow-same-origin',
   'allow-popups',
   'allow-popups-to-escape-sandbox',
-  'allow-presentation',
   'allow-top-navigation',
 ].join(' ');
 

--- a/src/utils/xhr.js
+++ b/src/utils/xhr.js
@@ -23,6 +23,9 @@ export async function successfulFetch(win, ...args) {
 }
 
 export function idleSuccessfulFetch(win, ...args) {
+  if (!('requestIdleCallback' in win)) {
+    return successfulFetch(win, ...args);
+  }
   const {promise, reject, resolve} = new Deferred();
   win.requestIdleCallback(() => {
     successfulFetch(win, ...args).then(resolve, reject);


### PR DESCRIPTION
- `allow-presentation` is Chrome-only and unnecessary.
- Don't `requestIdleCallback` if API is not available.